### PR TITLE
[OJI-2 + OJI-3] Drizzle schema + Migration script content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ logs
 
 .mcp.json
 .claude/settings.local.json
+
+# Migration output
+scripts/migrate-content-map.json

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,6 +13,7 @@ export default defineNuxtConfig({
   hub: {
     db: {
       dialect: 'mysql',
+      casing: 'snake_case',
       // Matikan auto-migrate saat build & dev — jalankan manual via pnpm db:migrate
       applyMigrationsDuringBuild: false,
       applyMigrationsDuringDev: false,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "db:generate": "nuxt db generate",
-    "db:migrate": "nuxt db migrate"
+    "db:migrate": "nuxt db migrate",
+    "migrate:content": "tsx scripts/migrate-content.ts",
+    "migrate:users": "tsx scripts/migrate-users.ts",
+    "migrate:media": "tsx scripts/migrate-media.ts"
   },
   "dependencies": {
     "@nuxt/image": "^2.0.0",
@@ -25,7 +28,9 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",
+    "dotenv": "^17.4.1",
     "drizzle-kit": "^0.31.10",
+    "tsx": "^4.21.0",
     "typescript": "latest",
     "vue-tsc": "latest",
     "wrangler": "^4.81.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,15 @@ importers:
       '@nuxt/devtools':
         specifier: latest
         version: 4.0.0-alpha.4(@pnpm/logger@1001.0.1)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260412.1)(mysql2@3.22.0(@types/node@25.6.0)))(mysql2@3.22.0(@types/node@25.6.0)))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
+      dotenv:
+        specifier: ^17.4.1
+        version: 17.4.1
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: latest
         version: 6.0.2

--- a/scripts/migrate-content.ts
+++ b/scripts/migrate-content.ts
@@ -1,0 +1,288 @@
+/**
+ * Migration script: Posts, Pages, Categories
+ * Source: WordPress REST API (https://ojialanshori.com/wp-json/wp/v2/)
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-content.ts
+ *
+ * Requirements:
+ *   - MYSQL_URL set in .env
+ *   - E1-002 schema & migrations already applied to the database
+ */
+import 'dotenv/config'
+import { drizzle } from 'drizzle-orm/mysql2'
+import mysql from 'mysql2/promise'
+import { eq } from 'drizzle-orm'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import * as schema from '../server/db/schema.js'
+import type { CategoryType, PageStatus } from '../server/db/schema.js'
+
+// ─── WordPress API types ─────────────────────────────────────────────────────
+
+interface WPCategory {
+  id: number
+  name: string
+  slug: string
+  parent: number
+}
+
+interface WPPost {
+  id: number
+  slug: string
+  title: { rendered: string }
+  content: { rendered: string }
+  excerpt: { rendered: string }
+  date: string
+  author: number
+  categories: number[]
+  featured_media: number
+  _embedded?: {
+    'wp:featuredmedia'?: Array<{ source_url?: string }>
+  }
+}
+
+interface WPPage {
+  id: number
+  slug: string
+  status: string
+  title: { rendered: string }
+  content: { rendered: string }
+  date: string
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const WP_API = 'https://ojialanshori.com/wp-json/wp/v2'
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&hellip;/g, '...')
+    .replace(/&#8230;/g, '...')
+    .replace(/\[&hellip;\]/g, '...')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .trim()
+}
+
+async function fetchAll<T>(endpoint: string, params: Record<string, string> = {}): Promise<T[]> {
+  const results: T[] = []
+  let page = 1
+  let totalPages = 1
+
+  while (page <= totalPages) {
+    const url = new URL(`${WP_API}${endpoint}`)
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+    url.searchParams.set('page', String(page))
+    url.searchParams.set('per_page', '100')
+
+    const res = await fetch(url.toString())
+    if (!res.ok) throw new Error(`WP API ${res.status}: ${url}`)
+
+    if (page === 1) {
+      totalPages = parseInt(res.headers.get('X-WP-TotalPages') ?? '1', 10)
+      const total = res.headers.get('X-WP-Total')
+      console.log(`    Total: ${total} items across ${totalPages} pages`)
+    }
+
+    const data = (await res.json()) as T[]
+    results.push(...data)
+    console.log(`    Page ${page}/${totalPages} — fetched ${data.length} items`)
+    page++
+  }
+
+  return results
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!process.env.MYSQL_URL) {
+    throw new Error('MYSQL_URL is not set. Check your .env file.')
+  }
+
+  console.log('🔌 Connecting to database...')
+  const connection = await mysql.createConnection(process.env.MYSQL_URL)
+  const db = drizzle(connection, { schema, casing: 'snake_case' })
+
+  const mapping = {
+    categories: {} as Record<number, number>,
+    posts: {} as Record<number, number>,
+    pages: {} as Record<number, number>,
+  }
+
+  // ── 1. Categories ───────────────────────────────────────────────────────────
+
+  console.log('\n📁 Migrating categories...')
+  const wpCategories = await fetchAll<WPCategory>('/categories')
+
+  // Build wp_id → slug map for parent resolution
+  const wpSlugById = new Map(wpCategories.map((c) => [c.id, c.slug]))
+
+  // Determine category type based on slug ancestry
+  function getCategoryType(slug: string, parentId: number): CategoryType {
+    if (slug === 'pena-santri') return 'pena_santri'
+    if (parentId) {
+      const parentSlug = wpSlugById.get(parentId)
+      if (parentSlug === 'pena-santri') return 'pena_santri'
+    }
+    return 'berita'
+  }
+
+  // Sort: parents (parent === 0) first so FK references resolve in order
+  const sortedCats = [...wpCategories].sort((a, b) => a.parent - b.parent)
+
+  let catOk = 0, catErr = 0
+  for (const cat of sortedCats) {
+    const type = getCategoryType(cat.slug, cat.parent)
+    const parentNewId = cat.parent ? (mapping.categories[cat.parent] ?? null) : null
+
+    try {
+      // Check if already exists (idempotent)
+      const existing = await db.query.categories.findFirst({
+        where: eq(schema.categories.slug, cat.slug),
+      })
+
+      if (existing) {
+        mapping.categories[cat.id] = existing.id
+        catOk++
+        continue
+      }
+
+      const result = await db.insert(schema.categories).values({
+        name: cat.name,
+        slug: cat.slug,
+        parentId: parentNewId,
+        type,
+      })
+      mapping.categories[cat.id] = result[0].insertId
+      catOk++
+    }
+    catch (e) {
+      console.error(`  ❌ Category "${cat.slug}":`, (e as Error).message)
+      catErr++
+    }
+  }
+  console.log(`  ✅ ${catOk} ok  ❌ ${catErr} errors`)
+
+  // ── 2. Posts ────────────────────────────────────────────────────────────────
+
+  console.log('\n📝 Migrating posts...')
+  const wpPosts = await fetchAll<WPPost>('/posts', {
+    status: 'publish',
+    _embed: 'wp:featuredmedia',
+  })
+
+  // Default author ID — placeholder until E1-004 (user migration)
+  // All posts temporarily attributed to author ID 1 (superadmin)
+  const PLACEHOLDER_AUTHOR_ID = 1
+
+  let postOk = 0, postErr = 0
+  for (const post of wpPosts) {
+    const categoryNewId = post.categories[0]
+      ? (mapping.categories[post.categories[0]] ?? null)
+      : null
+
+    if (!categoryNewId) {
+      console.warn(`  ⚠️  Post "${post.slug}" has no mapped category (wp_categories: ${post.categories})`)
+    }
+
+    const featuredImageUrl = post._embedded?.['wp:featuredmedia']?.[0]?.source_url ?? null
+
+    try {
+      const existing = await db.query.posts.findFirst({
+        where: eq(schema.posts.slug, post.slug),
+      })
+
+      if (existing) {
+        mapping.posts[post.id] = existing.id
+        postOk++
+        continue
+      }
+
+      const result = await db.insert(schema.posts).values({
+        title: stripHtml(post.title.rendered),
+        slug: post.slug,
+        content: post.content.rendered,
+        excerpt: stripHtml(post.excerpt.rendered) || null,
+        featuredImage: featuredImageUrl,
+        categoryId: categoryNewId ?? 1,
+        authorId: PLACEHOLDER_AUTHOR_ID,
+        status: 'published',
+        publishedAt: new Date(post.date),
+        createdAt: new Date(post.date),
+        updatedAt: new Date(post.date),
+      })
+      mapping.posts[post.id] = result[0].insertId
+      postOk++
+    }
+    catch (e) {
+      console.error(`  ❌ Post "${post.slug}":`, (e as Error).message)
+      postErr++
+    }
+  }
+  console.log(`  ✅ ${postOk} ok  ❌ ${postErr} errors`)
+
+  // ── 3. Pages ────────────────────────────────────────────────────────────────
+
+  console.log('\n📄 Migrating pages...')
+  const wpPages = await fetchAll<WPPage>('/pages')
+
+  let pageOk = 0, pageErr = 0
+  for (const page of wpPages) {
+    const status: PageStatus = page.status === 'publish' ? 'published' : 'draft'
+
+    try {
+      const existing = await db.query.pages.findFirst({
+        where: eq(schema.pages.slug, page.slug),
+      })
+
+      if (existing) {
+        mapping.pages[page.id] = existing.id
+        pageOk++
+        continue
+      }
+
+      const result = await db.insert(schema.pages).values({
+        title: stripHtml(page.title.rendered),
+        slug: page.slug,
+        content: page.content.rendered,
+        status,
+        updatedAt: new Date(page.date),
+      })
+      mapping.pages[page.id] = result[0].insertId
+      pageOk++
+    }
+    catch (e) {
+      console.error(`  ❌ Page "${page.slug}":`, (e as Error).message)
+      pageErr++
+    }
+  }
+  console.log(`  ✅ ${pageOk} ok  ❌ ${pageErr} errors`)
+
+  // ── 4. Save mapping for E1-005 (media migration) ────────────────────────────
+
+  const mapPath = path.join(process.cwd(), 'scripts/migrate-content-map.json')
+  await fs.writeFile(mapPath, JSON.stringify(mapping, null, 2), 'utf-8')
+  console.log(`\n💾 Mapping saved to ${mapPath}`)
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+
+  console.log('\n🎉 Migration complete!')
+  console.log(`   Categories : ${Object.keys(mapping.categories).length}`)
+  console.log(`   Posts      : ${Object.keys(mapping.posts).length}`)
+  console.log(`   Pages      : ${Object.keys(mapping.pages).length}`)
+  console.log('\n⚠️  Note: post.authorId is set to placeholder (1) until E1-004 user migration runs.')
+  console.log('⚠️  Note: post.featuredImage contains original WP URL, will be updated by E1-005.')
+
+  await connection.end()
+}
+
+main().catch((err) => {
+  console.error('\n💥 Migration failed:', err)
+  process.exit(1)
+})

--- a/server/db/migrations/mysql/0000_deep_thundra.sql
+++ b/server/db/migrations/mysql/0000_deep_thundra.sql
@@ -1,0 +1,82 @@
+CREATE TABLE `banners` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`text` varchar(500) NOT NULL,
+	`link` varchar(500),
+	`is_active` boolean NOT NULL DEFAULT false,
+	`start_date` date,
+	`end_date` date,
+	CONSTRAINT `banners_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `categories` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`name` varchar(100) NOT NULL,
+	`slug` varchar(100) NOT NULL,
+	`parent_id` int,
+	`type` enum('berita','pena_santri') NOT NULL,
+	CONSTRAINT `categories_id` PRIMARY KEY(`id`),
+	CONSTRAINT `categories_slug_unique` UNIQUE(`slug`)
+);
+--> statement-breakpoint
+CREATE TABLE `gallery` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`title` varchar(255) NOT NULL,
+	`image_path` varchar(500) NOT NULL,
+	`album` varchar(100),
+	`order` int NOT NULL DEFAULT 0,
+	`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT `gallery_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `pages` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`title` varchar(255) NOT NULL,
+	`slug` varchar(255) NOT NULL,
+	`content` longtext NOT NULL,
+	`status` enum('draft','published') NOT NULL DEFAULT 'draft',
+	`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `pages_id` PRIMARY KEY(`id`),
+	CONSTRAINT `pages_slug_unique` UNIQUE(`slug`)
+);
+--> statement-breakpoint
+CREATE TABLE `posts` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`title` varchar(255) NOT NULL,
+	`slug` varchar(255) NOT NULL,
+	`content` longtext NOT NULL,
+	`excerpt` text,
+	`featured_image` varchar(500),
+	`category_id` int NOT NULL,
+	`author_id` int NOT NULL,
+	`status` enum('draft','pending_review','published','rejected') NOT NULL DEFAULT 'draft',
+	`rejection_note` text,
+	`published_at` timestamp,
+	`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `posts_id` PRIMARY KEY(`id`),
+	CONSTRAINT `posts_slug_unique` UNIQUE(`slug`)
+);
+--> statement-breakpoint
+CREATE TABLE `settings` (
+	`key` varchar(100) NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `settings_key` PRIMARY KEY(`key`)
+);
+--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`name` varchar(255) NOT NULL,
+	`username` varchar(100) NOT NULL,
+	`email` varchar(255) NOT NULL,
+	`password_hash` varchar(255) NOT NULL,
+	`password_type` enum('phpass','bcrypt') NOT NULL DEFAULT 'phpass',
+	`role` enum('superadmin','pengurus','reviewer','santri') NOT NULL DEFAULT 'santri',
+	`avatar_path` varchar(500),
+	`is_active` boolean NOT NULL DEFAULT true,
+	`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `users_id` PRIMARY KEY(`id`),
+	CONSTRAINT `users_username_unique` UNIQUE(`username`),
+	CONSTRAINT `users_email_unique` UNIQUE(`email`)
+);

--- a/server/db/migrations/mysql/0001_numerous_slyde.sql
+++ b/server/db/migrations/mysql/0001_numerous_slyde.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `categories` ADD CONSTRAINT `categories_parent_id_categories_id_fk` FOREIGN KEY (`parent_id`) REFERENCES `categories`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `posts` ADD CONSTRAINT `posts_category_id_categories_id_fk` FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `posts` ADD CONSTRAINT `posts_author_id_users_id_fk` FOREIGN KEY (`author_id`) REFERENCES `users`(`id`) ON DELETE no action ON UPDATE no action;

--- a/server/db/migrations/mysql/meta/0000_snapshot.json
+++ b/server/db/migrations/mysql/meta/0000_snapshot.json
@@ -1,0 +1,539 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "a9e07bd6-81a1-49e3-864d-ea9d1e959ddb",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "banners_id": {
+          "name": "banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('berita','pena_santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "gallery": {
+      "name": "gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gallery_id": {
+          "name": "gallery_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "pages": {
+      "name": "pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','published')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pages_id": {
+          "name": "pages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "pages_slug_unique": {
+          "name": "pages_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured_image": {
+          "name": "featured_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','pending_review','published','rejected')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "rejection_note": {
+          "name": "rejection_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_key": {
+          "name": "settings_key",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_type": {
+          "name": "password_type",
+          "type": "enum('phpass','bcrypt')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'phpass'"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('superadmin','pengurus','reviewer','santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'santri'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/mysql/meta/0001_snapshot.json
+++ b/server/db/migrations/mysql/meta/0001_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "8006ea6f-dace-46d6-a26a-ab5ca63a8421",
+  "prevId": "a9e07bd6-81a1-49e3-864d-ea9d1e959ddb",
+  "tables": {
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "banners_id": {
+          "name": "banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('berita','pena_santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "gallery": {
+      "name": "gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gallery_id": {
+          "name": "gallery_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "pages": {
+      "name": "pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','published')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pages_id": {
+          "name": "pages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "pages_slug_unique": {
+          "name": "pages_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured_image": {
+          "name": "featured_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','pending_review','published','rejected')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "rejection_note": {
+          "name": "rejection_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_category_id_categories_id_fk": {
+          "name": "posts_category_id_categories_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_key": {
+          "name": "settings_key",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_type": {
+          "name": "password_type",
+          "type": "enum('phpass','bcrypt')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'phpass'"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('superadmin','pengurus','reviewer','santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'santri'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/mysql/meta/_journal.json
+++ b/server/db/migrations/mysql/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1775988059204,
+      "tag": "0000_deep_thundra",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1775988093118,
+      "tag": "0001_numerous_slyde",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,0 +1,121 @@
+import {
+  mysqlTable,
+  int,
+  varchar,
+  text,
+  longtext,
+  boolean,
+  timestamp,
+  date,
+  mysqlEnum,
+  type AnyMySqlColumn,
+} from 'drizzle-orm/mysql-core'
+import { relations, sql } from 'drizzle-orm'
+
+// ─── TypeScript types ────────────────────────────────────────────────────────
+
+export type Role = 'superadmin' | 'pengurus' | 'reviewer' | 'santri'
+export type PostStatus = 'draft' | 'pending_review' | 'published' | 'rejected'
+export type PasswordType = 'phpass' | 'bcrypt'
+export type PageStatus = 'draft' | 'published'
+export type CategoryType = 'berita' | 'pena_santri'
+
+// ─── Tables ──────────────────────────────────────────────────────────────────
+
+export const users = mysqlTable('users', {
+  id: int().primaryKey().autoincrement(),
+  name: varchar({ length: 255 }).notNull(),
+  username: varchar({ length: 100 }).notNull().unique(),
+  email: varchar({ length: 255 }).notNull().unique(),
+  passwordHash: varchar({ length: 255 }).notNull(),
+  passwordType: mysqlEnum(['phpass', 'bcrypt']).notNull().default('phpass'),
+  role: mysqlEnum(['superadmin', 'pengurus', 'reviewer', 'santri']).notNull().default('santri'),
+  avatarPath: varchar({ length: 500 }),
+  isActive: boolean().notNull().default(true),
+  createdAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`).onUpdateNow(),
+})
+
+export const categories = mysqlTable('categories', {
+  id: int().primaryKey().autoincrement(),
+  name: varchar({ length: 100 }).notNull(),
+  slug: varchar({ length: 100 }).notNull().unique(),
+  parentId: int().references((): AnyMySqlColumn => categories.id),
+  type: mysqlEnum(['berita', 'pena_santri']).notNull(),
+})
+
+export const posts = mysqlTable('posts', {
+  id: int().primaryKey().autoincrement(),
+  title: varchar({ length: 255 }).notNull(),
+  slug: varchar({ length: 255 }).notNull().unique(),
+  content: longtext().notNull(),
+  excerpt: text(),
+  featuredImage: varchar({ length: 500 }),
+  categoryId: int().notNull().references(() => categories.id),
+  authorId: int().notNull().references(() => users.id),
+  status: mysqlEnum(['draft', 'pending_review', 'published', 'rejected']).notNull().default('draft'),
+  rejectionNote: text(),
+  publishedAt: timestamp(),
+  createdAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`).onUpdateNow(),
+})
+
+export const pages = mysqlTable('pages', {
+  id: int().primaryKey().autoincrement(),
+  title: varchar({ length: 255 }).notNull(),
+  slug: varchar({ length: 255 }).notNull().unique(),
+  content: longtext().notNull(),
+  status: mysqlEnum(['draft', 'published']).notNull().default('draft'),
+  updatedAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`).onUpdateNow(),
+})
+
+export const gallery = mysqlTable('gallery', {
+  id: int().primaryKey().autoincrement(),
+  title: varchar({ length: 255 }).notNull(),
+  imagePath: varchar({ length: 500 }).notNull(),
+  album: varchar({ length: 100 }),
+  order: int().notNull().default(0),
+  createdAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`),
+})
+
+export const banners = mysqlTable('banners', {
+  id: int().primaryKey().autoincrement(),
+  text: varchar({ length: 500 }).notNull(),
+  link: varchar({ length: 500 }),
+  isActive: boolean().notNull().default(false),
+  startDate: date(),
+  endDate: date(),
+})
+
+export const settings = mysqlTable('settings', {
+  key: varchar({ length: 100 }).primaryKey(),
+  value: text().notNull(),
+  updatedAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`).onUpdateNow(),
+})
+
+// ─── Relations ───────────────────────────────────────────────────────────────
+
+export const usersRelations = relations(users, ({ many }) => ({
+  posts: many(posts),
+}))
+
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+  parent: one(categories, {
+    fields: [categories.parentId],
+    references: [categories.id],
+    relationName: 'parentChild',
+  }),
+  children: many(categories, { relationName: 'parentChild' }),
+  posts: many(posts),
+}))
+
+export const postsRelations = relations(posts, ({ one }) => ({
+  category: one(categories, {
+    fields: [posts.categoryId],
+    references: [categories.id],
+  }),
+  author: one(users, {
+    fields: [posts.authorId],
+    references: [users.id],
+  }),
+}))


### PR DESCRIPTION
## Overview
PR ini membawa perubahan OJI-2 dan OJI-3 ke main. PR sebelumnya (#3 dan #4) secara tidak sengaja di-merge ke branch chain, bukan ke main.

## Changes

**OJI-2 — Drizzle ORM schema:**
- `nuxt.config.ts` — tambah `casing: 'snake_case'` ke `hub.db`
- `server/db/schema.ts` — definisi 7 tabel + TypeScript enums + ORM relations + FK constraints
- `server/db/migrations/mysql/` — 2 migration files (CREATE TABLE + ALTER TABLE FK)

**OJI-3 — Migration script Posts/Pages/Categories:**
- `scripts/migrate-content.ts` — fetch dari WP REST API, handle pagination, insert ke DB
- `package.json` — tambah `tsx`, `dotenv` devDeps + `migrate:content/users/media` scripts
- `.gitignore` — ignore `scripts/migrate-content-map.json`

## Testing
1. `pnpm db:migrate` — apply migrations ke DB lokal
2. `pnpm migrate:content` — jalankan migrasi konten dari WP REST API

## Linear
- https://linear.app/umarsani1602/issue/OJI-2/e1-002-drizzle-orm-schema-semua-tabel-mysql
- https://linear.app/umarsani1602/issue/OJI-3/e1-003-migration-script-posts-pages-categories