### PR TITLE
[OJI-20] E1-002 — Setup NuxtHub + Konfigurasi Cloudflare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ BREVO_API_KEY=
 # Disqus
 DISQUS_SHORTNAME=ojialanshori
 
+# Cloudflare R2 — digunakan oleh scripts/migrate-media.ts
+# Buat API token di Cloudflare Dashboard > R2 > Manage API tokens
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=ojialanshori
+R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+
 # WordPress Migration (digunakan oleh scripts/migrate-*.ts saja)
 WP_MYSQL_URL=mysql://user:password@wp-host:3306/wp_database
 WP_TABLE_PREFIX=wp_

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Build
+        run: pnpm build
+        env:
+          MYSQL_URL: ${{ secrets.MYSQL_URL }}
+          NUXT_SESSION_SECRET: ${{ secrets.NUXT_SESSION_SECRET }}
+          BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
+          DISQUS_SHORTNAME: ojialanshori
+
+      - name: Deploy to Cloudflare Pages
+        run: npx wrangler pages deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/server/api/health.get.ts
+++ b/server/api/health.get.ts
@@ -3,8 +3,7 @@ import mysql from 'mysql2/promise'
 import { sql } from 'drizzle-orm'
 
 export default defineEventHandler(async () => {
-  const config = useRuntimeConfig()
-  const mysqlUrl = process.env.MYSQL_URL || config.mysqlUrl
+  const mysqlUrl = process.env.MYSQL_URL
 
   if (!mysqlUrl) {
     throw createError({ statusCode: 500, statusMessage: 'MYSQL_URL is not configured' })

--- a/server/api/health.get.ts
+++ b/server/api/health.get.ts
@@ -1,0 +1,23 @@
+import { drizzle } from 'drizzle-orm/mysql2'
+import mysql from 'mysql2/promise'
+import { sql } from 'drizzle-orm'
+
+export default defineEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const mysqlUrl = process.env.MYSQL_URL || config.mysqlUrl
+
+  if (!mysqlUrl) {
+    throw createError({ statusCode: 500, statusMessage: 'MYSQL_URL is not configured' })
+  }
+
+  const connection = await mysql.createConnection(mysqlUrl)
+  const db = drizzle(connection)
+
+  try {
+    await db.execute(sql`SELECT 1`)
+    return { status: 'ok', db: 'connected' }
+  }
+  finally {
+    await connection.end()
+  }
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,15 +14,15 @@
     },
   ],
 
-  // Cloudflare KV — key-value store
+  // Cloudflare KV — NuxtHub expects binding names "KV" and "CACHE"
   "kv_namespaces": [
     {
-      "binding": "OMAH_NGAJI_KV",
+      "binding": "KV",
       "id": "156fd4abc0f644d1bb7ee52a03bb5bcc",
       "preview_id": "156fd4abc0f644d1bb7ee52a03bb5bcc",
     },
     {
-      "binding": "OMAH_NGAJI_CACHE",
+      "binding": "CACHE",
       "id": "17aff56a91244275a2db10022f96d848",
       "preview_id": "17aff56a91244275a2db10022f96d848",
     },


### PR DESCRIPTION
## Overview
Setup konfigurasi NuxtHub dan Cloudflare agar project siap deploy ke Cloudflare Pages.

- Fix KV binding names dari custom names ke `KV` dan `CACHE` sesuai konvensi NuxtHub
- Bucket name disesuaikan dengan yang sudah dibuat user: `ojialanshori`

## Changes
- `wrangler.jsonc` — fix KV binding names ke `KV` dan `CACHE` (NuxtHub convention)
- `.env.example` — tambah R2 env variables untuk migration script
- `server/api/health.get.ts` — GET /api/health untuk verifikasi koneksi DB
- `.github/workflows/deploy.yml` — CI/CD auto-deploy ke Cloudflare Pages saat push ke main

## Testing
1. Jalankan `pnpm dev` lalu buka `http://localhost:3000/api/health`
2. Response harus: `{"status":"ok","db":"connected"}`

## Notes
- GitHub Secrets perlu diset manual: `MYSQL_URL`, `NUXT_SESSION_SECRET`, `BREVO_API_KEY`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
- R2 API token (untuk migration media) dibuat terpisah di Cloudflare R2 dashboard

## Linear
https://linear.app/umarsani1602/issue/OJI-20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health status endpoint.
  * Added an automated deployment pipeline for Cloudflare Pages (triggers on main).

* **Configuration**
  * Introduced Cloudflare R2 environment variables (access key, secret, bucket, endpoint).
  * Renamed KV namespace bindings to simplified names for deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->