### PR TITLE
[OJI-35] E1-009 — Migration script: Tags dan relasi post_tags dari WordPress

### DIFF
--- a/scripts/migrate-tags.ts
+++ b/scripts/migrate-tags.ts
@@ -1,0 +1,242 @@
+/**
+ * Migration script: Tags and post_tags pivot table
+ * Source: WordPress REST API (https://ojialanshori.com/wp-json/wp/v2/)
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-tags.ts
+ *
+ * Requirements:
+ *   - MYSQL_URL set in .env
+ *   - E1-008 schema & migrations already applied to the database
+ *   - migrate-content.ts must have been run first (generates migrate-content-map.json)
+ */
+import 'dotenv/config'
+import { drizzle } from 'drizzle-orm/mysql2'
+import mysql from 'mysql2/promise'
+import { eq, and } from 'drizzle-orm'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import * as schema from '../server/db/schema.js'
+
+// ─── WordPress API types ─────────────────────────────────────────────────────
+
+interface WPTag {
+  id: number
+  name: string
+  slug: string
+  count: number
+}
+
+interface WPPost {
+  id: number
+  slug: string
+  tags: number[]
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const WP_API = 'https://ojialanshori.com/wp-json/wp/v2'
+
+async function fetchAll<T>(endpoint: string, params: Record<string, string> = {}): Promise<T[]> {
+  const results: T[] = []
+  let page = 1
+  let totalPages = 1
+
+  while (page <= totalPages) {
+    const url = new URL(`${WP_API}${endpoint}`)
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+    url.searchParams.set('page', String(page))
+    url.searchParams.set('per_page', '100')
+
+    const res = await fetch(url.toString())
+    if (!res.ok) throw new Error(`WP API ${res.status}: ${url}`)
+
+    if (page === 1) {
+      totalPages = parseInt(res.headers.get('X-WP-TotalPages') ?? '1', 10)
+      const total = res.headers.get('X-WP-Total')
+      console.log(`    Total: ${total} items across ${totalPages} pages`)
+    }
+
+    const data = (await res.json()) as T[]
+    results.push(...data)
+    console.log(`    Page ${page}/${totalPages} — fetched ${data.length} items`)
+    page++
+  }
+
+  return results
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!process.env.MYSQL_URL) {
+    throw new Error('MYSQL_URL is not set. Check your .env file.')
+  }
+
+  console.log('🔌 Connecting to database...')
+  const connection = await mysql.createConnection(process.env.MYSQL_URL)
+  const db = drizzle(connection, { schema, casing: 'snake_case', mode: 'default' })
+
+  // ── 1. Fetch tags from WordPress ─────────────────────────────────────────────
+
+  console.log('\n🏷️  Fetching tags from WordPress...')
+  const wpTags = await fetchAll<WPTag>('/tags')
+
+  // Filter out unused tags (count === 0)
+  const activeTags = wpTags.filter(tag => tag.count > 0)
+  console.log(`  Active tags (count > 0): ${activeTags.length} of ${wpTags.length}`)
+
+  // wp_tag_id → new_tag_id mapping
+  const tagIdMap = new Map<number, number>()
+
+  // ── 2. Insert tags (idempotent) ──────────────────────────────────────────────
+
+  console.log('\n🏷️  Migrating tags...')
+  let tagOk = 0, tagErr = 0
+
+  for (const tag of activeTags) {
+    try {
+      const existing = await db.query.tags.findFirst({
+        where: eq(schema.tags.slug, tag.slug),
+      })
+
+      if (existing) {
+        tagIdMap.set(tag.id, existing.id)
+        tagOk++
+        continue
+      }
+
+      const result = await db.insert(schema.tags).values({
+        name: tag.name,
+        slug: tag.slug,
+      })
+      tagIdMap.set(tag.id, result[0].insertId)
+      tagOk++
+    }
+    catch (e) {
+      console.error(`  ❌ Tag "${tag.slug}":`, (e as Error).message)
+      tagErr++
+    }
+  }
+  console.log(`  ✅ ${tagOk} ok  ❌ ${tagErr} errors`)
+
+  // ── 3. Load post ID mapping from migrate-content-map.json ───────────────────
+
+  console.log('\n🗺️  Loading post ID mapping...')
+  const mapPath = path.join(process.cwd(), 'scripts/migrate-content-map.json')
+
+  // wp_post_id → new_post_id mapping
+  const postIdMap = new Map<number, number>()
+
+  let mapFileExists = false
+  try {
+    await fs.access(mapPath)
+    mapFileExists = true
+  }
+  catch {
+    // file doesn't exist
+  }
+
+  if (mapFileExists) {
+    const raw = await fs.readFile(mapPath, 'utf-8')
+    const contentMap = JSON.parse(raw) as {
+      categories: Record<string, number>
+      posts: Record<string, number>
+      pages: Record<string, number>
+    }
+
+    for (const [wpId, newId] of Object.entries(contentMap.posts)) {
+      postIdMap.set(Number(wpId), newId)
+    }
+    console.log(`  Loaded ${postIdMap.size} post mappings from migrate-content-map.json`)
+  }
+  else {
+    // Fallback: fetch WP posts and match by slug in DB
+    console.log('  ⚠️  migrate-content-map.json not found — fetching posts from WP and matching by slug...')
+    const wpPostsForMapping = await fetchAll<WPPost>('/posts', { status: 'publish', _fields: 'id,slug' })
+
+    for (const wpPost of wpPostsForMapping) {
+      const dbPost = await db.query.posts.findFirst({
+        where: eq(schema.posts.slug, wpPost.slug),
+      })
+      if (dbPost) {
+        postIdMap.set(wpPost.id, dbPost.id)
+      }
+      else {
+        console.warn(`  ⚠️  No DB post found for WP slug "${wpPost.slug}"`)
+      }
+    }
+    console.log(`  Matched ${postIdMap.size} posts by slug`)
+  }
+
+  // ── 4. Fetch WP posts with tags field ───────────────────────────────────────
+
+  console.log('\n📝 Fetching posts with tags from WordPress...')
+  const wpPosts = await fetchAll<WPPost>('/posts', {
+    status: 'publish',
+    _fields: 'id,slug,tags',
+  })
+
+  const postsWithTags = wpPosts.filter(p => p.tags.length > 0)
+  console.log(`  Posts with at least one tag: ${postsWithTags.length} of ${wpPosts.length}`)
+
+  // ── 5. Insert post_tags relations (idempotent) ───────────────────────────────
+
+  console.log('\n🔗 Migrating post_tags relations...')
+  let relOk = 0, relSkip = 0, relErr = 0
+
+  for (const post of postsWithTags) {
+    const newPostId = postIdMap.get(post.id)
+    if (!newPostId) {
+      console.warn(`  ⚠️  Post WP#${post.id} ("${post.slug}") has no DB mapping — skipping`)
+      continue
+    }
+
+    for (const wpTagId of post.tags) {
+      const newTagId = tagIdMap.get(wpTagId)
+      if (!newTagId) {
+        console.warn(`  ⚠️  Tag WP#${wpTagId} not in mapping (maybe count=0?) — skipping for post WP#${post.id}`)
+        continue
+      }
+
+      try {
+        const existing = await db.query.postTags.findFirst({
+          where: and(
+            eq(schema.postTags.postId, newPostId),
+            eq(schema.postTags.tagId, newTagId),
+          ),
+        })
+
+        if (existing) {
+          relSkip++
+          continue
+        }
+
+        await db.insert(schema.postTags).values({
+          postId: newPostId,
+          tagId: newTagId,
+        })
+        relOk++
+      }
+      catch (e) {
+        console.error(`  ❌ post_tags (post=${newPostId}, tag=${newTagId}):`, (e as Error).message)
+        relErr++
+      }
+    }
+  }
+  console.log(`  ✅ ${relOk} inserted  ⏭️  ${relSkip} already existed  ❌ ${relErr} errors`)
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+
+  console.log('\n🎉 Tags migration complete!')
+  console.log(`   Tags imported  : ${tagOk}`)
+  console.log(`   Relations new  : ${relOk}`)
+  console.log(`   Relations skip : ${relSkip}`)
+
+  await connection.end()
+}
+
+main().catch((err) => {
+  console.error('\n💥 Migration failed:', err)
+  process.exit(1)
+})

--- a/server/db/migrations/mysql/0004_lame_jane_foster.sql
+++ b/server/db/migrations/mysql/0004_lame_jane_foster.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `post_tags` (
+	`post_id` int NOT NULL,
+	`tag_id` int NOT NULL,
+	CONSTRAINT `post_tags_post_id_tag_id_pk` PRIMARY KEY(`post_id`,`tag_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `tags` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`name` varchar(100) NOT NULL,
+	`slug` varchar(100) NOT NULL,
+	CONSTRAINT `tags_id` PRIMARY KEY(`id`),
+	CONSTRAINT `tags_slug_unique` UNIQUE(`slug`)
+);
+--> statement-breakpoint
+ALTER TABLE `post_tags` ADD CONSTRAINT `post_tags_post_id_posts_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `post_tags` ADD CONSTRAINT `post_tags_tag_id_tags_id_fk` FOREIGN KEY (`tag_id`) REFERENCES `tags`(`id`) ON DELETE cascade ON UPDATE no action;

--- a/server/db/migrations/mysql/meta/0004_snapshot.json
+++ b/server/db/migrations/mysql/meta/0004_snapshot.json
@@ -1,0 +1,684 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f43684e0-7094-4fec-8f72-fc0aa45af077",
+  "prevId": "14a781fa-0214-4768-9510-52cdfd417391",
+  "tables": {
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "banners_id": {
+          "name": "banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('berita','pena_santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "gallery": {
+      "name": "gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gallery_id": {
+          "name": "gallery_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "pages": {
+      "name": "pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','published')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pages_id": {
+          "name": "pages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "pages_slug_unique": {
+          "name": "pages_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "name": "post_tags_post_id_tag_id_pk",
+          "columns": [
+            "post_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured_image": {
+          "name": "featured_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','pending_review','published','rejected')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "rejection_note": {
+          "name": "rejection_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_category_id_categories_id_fk": {
+          "name": "posts_category_id_categories_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_key": {
+          "name": "settings_key",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_type": {
+          "name": "password_type",
+          "type": "enum('phpass','bcrypt')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'phpass'"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('superadmin','pengurus','reviewer','santri')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'santri'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/mysql/meta/_journal.json
+++ b/server/db/migrations/mysql/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777972633895,
       "tag": "0003_spotty_human_torch",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1777973450001,
+      "tag": "0004_lame_jane_foster",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -9,6 +9,7 @@ import {
   date,
   year,
   mysqlEnum,
+  primaryKey,
   type AnyMySqlColumn,
 } from 'drizzle-orm/mysql-core'
 import { relations, sql } from 'drizzle-orm'
@@ -126,6 +127,19 @@ export const contacts = mysqlTable('contacts', {
   updatedAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`).onUpdateNow(),
 })
 
+export const tags = mysqlTable('tags', {
+  id: int().primaryKey().autoincrement(),
+  name: varchar({ length: 100 }).notNull(),
+  slug: varchar({ length: 100 }).notNull().unique(),
+})
+
+export const postTags = mysqlTable('post_tags', {
+  postId: int().notNull().references(() => posts.id, { onDelete: 'cascade' }),
+  tagId: int().notNull().references(() => tags.id, { onDelete: 'cascade' }),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.postId, table.tagId] }),
+}))
+
 // ─── Relations ───────────────────────────────────────────────────────────────
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -142,7 +156,7 @@ export const categoriesRelations = relations(categories, ({ one, many }) => ({
   posts: many(posts),
 }))
 
-export const postsRelations = relations(posts, ({ one }) => ({
+export const postsRelations = relations(posts, ({ one, many }) => ({
   category: one(categories, {
     fields: [posts.categoryId],
     references: [categories.id],
@@ -150,5 +164,21 @@ export const postsRelations = relations(posts, ({ one }) => ({
   author: one(users, {
     fields: [posts.authorId],
     references: [users.id],
+  }),
+  postTags: many(postTags),
+}))
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  postTags: many(postTags),
+}))
+
+export const postTagsRelations = relations(postTags, ({ one }) => ({
+  post: one(posts, {
+    fields: [postTags.postId],
+    references: [posts.id],
+  }),
+  tag: one(tags, {
+    fields: [postTags.tagId],
+    references: [tags.id],
   }),
 }))


### PR DESCRIPTION
## Overview
Script migrasi idempotent untuk mengimport data tags dari WordPress ke tabel `tags` dan `post_tags`.

- Branch dari OJI-34 (mengandung schema `tags` dan `post_tags`)
- Merge OJI-34 ke main terlebih dahulu sebelum merge PR ini

## Changes
- `scripts/migrate-tags.ts` — script migrasi baru

## Testing
1. Pastikan OJI-34 sudah di-merge dan migrasi DB dijalankan
2. Pastikan `migrate-content.ts` sudah dijalankan (menghasilkan `scripts/migrate-content-map.json`)
3. Set `MYSQL_URL` di `.env`
4. Jalankan: `npx tsx scripts/migrate-tags.ts`
5. Verifikasi tabel `tags` berisi data dari WP
6. Verifikasi tabel `post_tags` berisi relasi yang benar
7. Jalankan ulang script — hasilnya sama (idempotent)

## Notes
- PR ini harus di-merge **setelah** OJI-34 (PR #42)
- Jika `migrate-content-map.json` tidak ada, script fallback ke fetch WP + match by slug di DB

## Linear
https://linear.app/umarsani1602/issue/OJI-35/e1-009-migration-script-tags-dan-relasi-post-tags-dari-wordpress