### PR TITLE
[OJI-41, OJI-29] E4-005 Profil Saya + E3-004 Post Detail (berita & pena santri)

### DIFF
--- a/app/components/public/PostDetail.vue
+++ b/app/components/public/PostDetail.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+type PostDetailData = {
+  id: number
+  title: string
+  slug: string
+  content: string
+  excerpt: string | null
+  featuredImage: string | null
+  publishedAt: string | Date | null
+  createdAt: string | Date
+  categorySlug: string
+  categoryName: string
+  categoryType: 'berita' | 'pena_santri'
+  authorName: string
+}
+
+const props = defineProps<{
+  post: PostDetailData
+  backPath: string
+  backLabel: string
+}>()
+
+const requestUrl = useRequestURL()
+const postUrl = computed(() => requestUrl.href)
+
+const dateFormatted = computed(() => {
+  const date = props.post.publishedAt ?? props.post.createdAt
+  return new Date(date).toLocaleDateString('id-ID', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+})
+
+const shareLinks = computed(() => ({
+  facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(postUrl.value)}`,
+  twitter: `https://twitter.com/intent/tweet?url=${encodeURIComponent(postUrl.value)}&text=${encodeURIComponent(props.post.title)}`,
+  whatsapp: `https://wa.me/?text=${encodeURIComponent(`${props.post.title} ${postUrl.value}`)}`,
+  linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl.value)}`,
+}))
+
+const shareButtons = computed(() => [
+  { label: 'Facebook', href: shareLinks.value.facebook },
+  { label: 'Twitter', href: shareLinks.value.twitter },
+  { label: 'WhatsApp', href: shareLinks.value.whatsapp },
+  { label: 'LinkedIn', href: shareLinks.value.linkedin },
+])
+</script>
+
+<template>
+  <article class="py-12 md:py-16">
+    <UContainer>
+      <div class="mx-auto max-w-3xl">
+        <!-- Back navigation -->
+        <NuxtLink
+          :to="backPath"
+          class="inline-flex items-center gap-1.5 text-sm text-muted hover:text-neutral-900 transition-colors mb-8"
+        >
+          <UIcon name="i-lucide-arrow-left" class="size-4 shrink-0" />
+          {{ backLabel }}
+        </NuxtLink>
+
+        <!-- Title -->
+        <h1 class="text-3xl font-bold leading-snug md:text-4xl md:leading-tight">
+          {{ post.title }}
+        </h1>
+
+        <!-- Meta -->
+        <p class="mt-4 text-sm text-muted">
+          oleh {{ post.authorName }}
+          <span class="mx-2 text-neutral-300">|</span>
+          {{ dateFormatted }}
+        </p>
+
+        <!-- Featured Image -->
+        <div class="mt-8 aspect-video overflow-hidden rounded-2xl bg-neutral-100">
+          <NuxtImg
+            v-if="post.featuredImage"
+            :src="post.featuredImage"
+            :alt="post.title"
+            class="h-full w-full object-cover"
+            loading="eager"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center text-neutral-300"
+          >
+            <UIcon name="i-lucide-image" class="size-14" />
+          </div>
+        </div>
+
+        <!-- Article Body -->
+        <div
+          class="prose prose-neutral mt-10 max-w-none leading-relaxed"
+          v-html="post.content"
+        />
+
+        <!-- Share -->
+        <div class="mt-12 border-t border-neutral-200 pt-8">
+          <p class="mb-4 text-sm font-medium">Bagikan artikel:</p>
+          <div class="flex flex-wrap gap-2">
+            <a
+              v-for="btn in shareButtons"
+              :key="btn.label"
+              :href="btn.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50"
+            >
+              <UIcon :name="btn.icon" class="size-4" :style="{ color: btn.color }" />
+              {{ btn.label }}
+            </a>
+          </div>
+        </div>
+
+        <!-- Disqus -->
+        <div class="mt-12 border-t border-neutral-200 pt-8">
+          <ClientOnly>
+            <DisqusComments
+              :identifier="post.slug"
+              :url="postUrl"
+              :title="post.title"
+            />
+          </ClientOnly>
+        </div>
+      </div>
+    </UContainer>
+  </article>
+</template>

--- a/app/pages/berita/[slug].vue
+++ b/app/pages/berita/[slug].vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+const route = useRoute()
+const slug = route.params.slug as string
+
+const { data, error } = await useFetch(`/api/public/posts/${slug}`, {
+  key: `public-post-${slug}`,
+})
+
+if (error.value?.statusCode === 404 || !data.value?.post) {
+  throw createError({ statusCode: 404, statusMessage: 'Halaman tidak ditemukan' })
+}
+
+const post = computed(() => data.value!.post)
+
+useSeoMeta({
+  title: post.value.title,
+  description: post.value.excerpt ?? undefined,
+  ogTitle: post.value.title,
+  ogDescription: post.value.excerpt ?? undefined,
+  ogImage: post.value.featuredImage ?? undefined,
+  ogType: 'article',
+})
+
+useHead({
+  script: [{
+    type: 'application/ld+json',
+    children: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: post.value.title,
+      datePublished: post.value.publishedAt ?? post.value.createdAt,
+      author: { '@type': 'Person', name: post.value.authorName },
+      image: post.value.featuredImage,
+    }),
+  }],
+})
+</script>
+
+<template>
+  <PublicPostDetail
+    :post="post"
+    back-path="/berita"
+    back-label="Berita"
+  />
+</template>

--- a/app/pages/dashboard/profile/index.vue
+++ b/app/pages/dashboard/profile/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { TabsItem } from '@nuxt/ui'
+
 definePageMeta({
   middleware: ['auth'],
 })
@@ -10,6 +12,11 @@ type User = {
   email: string
   role: 'superadmin' | 'pengurus' | 'reviewer' | 'santri'
   avatar: string | null
+  phone: string | null
+  university: string | null
+  faculty: string | null
+  major: string | null
+  yearEnrolled: number | null
   isActive: boolean
   createdAt: string
 }
@@ -24,18 +31,48 @@ const { data, refresh } = await useFetch<{ user: User }>('/api/dashboard/profile
 })
 
 const user = computed(() => data.value?.user)
+const joinYear = computed(() => user.value?.createdAt ? new Date(user.value.createdAt).getFullYear() : '—')
 
-// ── Section: Data Diri ──
-const profileForm = reactive({ name: '', username: '', email: '' })
-watchEffect(() => {
+const tabItems: TabsItem[] = [
+  { label: 'Informasi Pribadi', slot: 'informasi' },
+  { label: 'Keamanan', slot: 'keamanan' },
+]
+
+// ── Informasi Pribadi ────────────────────────────────────────────────────────
+
+const profileForm = reactive({
+  name: '',
+  phone: '',
+  university: '',
+  faculty: '',
+  major: '',
+  yearEnrolled: undefined as number | undefined,
+})
+
+const profileSaving = ref(false)
+const profileError = ref<string | null>(null)
+
+watch(user, (val) => {
+  if (!val) return
+  profileForm.name = val.name
+  profileForm.phone = val.phone ?? ''
+  profileForm.university = val.university ?? ''
+  profileForm.faculty = val.faculty ?? ''
+  profileForm.major = val.major ?? ''
+  profileForm.yearEnrolled = val.yearEnrolled ?? undefined
+}, { immediate: true, once: true })
+
+function resetProfileForm() {
   if (user.value) {
     profileForm.name = user.value.name
-    profileForm.username = user.value.username
-    profileForm.email = user.value.email
+    profileForm.phone = user.value.phone ?? ''
+    profileForm.university = user.value.university ?? ''
+    profileForm.faculty = user.value.faculty ?? ''
+    profileForm.major = user.value.major ?? ''
+    profileForm.yearEnrolled = user.value.yearEnrolled ?? undefined
   }
-})
-const profileError = ref<string | null>(null)
-const profileSaving = ref(false)
+  profileError.value = null
+}
 
 async function saveProfile() {
   profileError.value = null
@@ -43,7 +80,14 @@ async function saveProfile() {
   try {
     await $fetch('/api/dashboard/profile', {
       method: 'PATCH',
-      body: { ...profileForm },
+      body: {
+        name: profileForm.name,
+        phone: profileForm.phone || null,
+        university: profileForm.university || null,
+        faculty: profileForm.faculty || null,
+        major: profileForm.major || null,
+        yearEnrolled: profileForm.yearEnrolled ?? null,
+      },
     })
     toast.add({ title: 'Profil diperbarui', color: 'success', icon: 'i-lucide-check' })
     await Promise.all([refresh(), auth.fetch()])
@@ -58,7 +102,14 @@ async function saveProfile() {
   }
 }
 
-// ── Section: Password ──
+const currentYear = new Date().getFullYear()
+const yearOptions = Array.from({ length: 20 }, (_, i) => ({
+  label: String(currentYear - i),
+  value: currentYear - i,
+}))
+
+// ── Keamanan ─────────────────────────────────────────────────────────────────
+
 const passwordForm = reactive({
   oldPassword: '',
   newPassword: '',
@@ -69,6 +120,10 @@ const passwordSaving = ref(false)
 
 async function savePassword() {
   passwordError.value = null
+  if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+    passwordError.value = 'Konfirmasi password baru tidak cocok.'
+    return
+  }
   passwordSaving.value = true
   try {
     await $fetch('/api/dashboard/profile/password', {
@@ -90,7 +145,8 @@ async function savePassword() {
   }
 }
 
-// ── Section: Avatar ──
+// ── Avatar ───────────────────────────────────────────────────────────────────
+
 const fileInput = ref<HTMLInputElement | null>(null)
 const avatarUploading = ref(false)
 const avatarDeleting = ref(false)
@@ -159,143 +215,170 @@ async function deleteAvatar() {
 </script>
 
 <template>
-  <AppContent title="Profil Saya">
-    <div class="p-6 max-w-2xl space-y-6">
-        <!-- Section 1: Avatar -->
-        <UCard>
-          <template #header>
-            <h3 class="text-sm font-semibold text-neutral-700">
-              Foto Profil
-            </h3>
-          </template>
-
-          <div class="flex items-center gap-4">
-            <AppAvatar
-              :name="user?.name"
-              :src="user?.avatar"
-              size="3xl"
+  <UContainer class="max-w-2xl px-6 py-8">
+    <div class="space-y-6">
+      <!-- Card Profil -->
+      <div class="flex items-center gap-5 rounded-xl border border-neutral-200 bg-white p-6">
+        <div class="relative shrink-0">
+          <AppAvatar
+            :name="user?.name"
+            :src="user?.avatar"
+            size="3xl"
+          />
+          <button
+            type="button"
+            class="absolute -bottom-1 -right-1 rounded-full border border-neutral-200 bg-white p-1.5 shadow-sm transition-colors hover:bg-neutral-50"
+            :disabled="avatarUploading || avatarDeleting"
+            @click="pickFile"
+          >
+            <UIcon
+              :name="avatarUploading ? 'i-lucide-loader-circle' : 'i-lucide-camera'"
+              class="size-3.5 text-muted"
+              :class="{ 'animate-spin': avatarUploading }"
             />
-            <div class="flex flex-col gap-2">
-              <div class="flex gap-2">
-                <UButton
-                  icon="i-lucide-upload"
-                  size="sm"
-                  color="primary"
-                  :loading="avatarUploading"
-                  @click="pickFile"
+          </button>
+        </div>
+
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-lg font-semibold">{{ user?.name }}</p>
+          <div class="mt-1 flex items-center gap-2">
+            <UBadge color="primary" variant="subtle" size="sm">Santri</UBadge>
+            <span class="text-xs text-dimmed">Bergabung {{ joinYear }}</span>
+          </div>
+          <p class="mt-1 truncate text-sm text-muted">{{ user?.email }}</p>
+        </div>
+
+        <UButton
+          v-if="user?.avatar"
+          icon="i-lucide-trash-2"
+          color="error"
+          variant="ghost"
+          size="xs"
+          :loading="avatarDeleting"
+          aria-label="Hapus avatar"
+          @click="deleteAvatar"
+        />
+      </div>
+
+      <input
+        ref="fileInput"
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        class="hidden"
+        @change="onFileChange"
+      >
+
+      <!-- Tabs -->
+      <UTabs :items="tabItems" class="w-full">
+        <template #informasi>
+          <div class="mt-4 rounded-xl border border-neutral-200 bg-white p-6">
+            <form class="space-y-5" @submit.prevent="saveProfile">
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <UFormField label="Nama Lengkap" name="name" required class="sm:col-span-2">
+                  <UInput v-model="profileForm.name" :disabled="profileSaving" class="w-full" />
+                </UFormField>
+
+                <UFormField label="No. HP / WhatsApp" name="phone">
+                  <UInput v-model="profileForm.phone" :disabled="profileSaving" class="w-full" />
+                </UFormField>
+
+                <UFormField label="Angkatan" name="yearEnrolled">
+                  <USelect
+                    v-model="profileForm.yearEnrolled"
+                    :items="yearOptions"
+                    placeholder="Pilih angkatan"
+                    :disabled="profileSaving"
+                    class="w-full"
+                  />
+                </UFormField>
+
+                <UFormField label="Universitas / Kampus" name="university">
+                  <UInput v-model="profileForm.university" :disabled="profileSaving" class="w-full" />
+                </UFormField>
+
+                <UFormField label="Fakultas" name="faculty">
+                  <UInput v-model="profileForm.faculty" :disabled="profileSaving" class="w-full" />
+                </UFormField>
+
+                <UFormField label="Jurusan" name="major" class="sm:col-span-2">
+                  <UInput v-model="profileForm.major" :disabled="profileSaving" class="w-full" />
+                </UFormField>
+
+                <UFormField
+                  label="Email"
+                  name="email"
+                  hint="Email tidak bisa diubah"
+                  class="sm:col-span-2"
                 >
-                  {{ user?.avatar ? 'Ganti Foto' : 'Upload Foto' }}
+                  <UInput :model-value="user?.email" disabled class="w-full" />
+                </UFormField>
+              </div>
+
+              <p v-if="profileError" class="rounded bg-red-50 px-3 py-2 text-sm text-red-600">
+                {{ profileError }}
+              </p>
+
+              <div class="flex justify-end gap-2">
+                <UButton
+                  type="button"
+                  color="neutral"
+                  variant="outline"
+                  :disabled="profileSaving"
+                  @click="resetProfileForm"
+                >
+                  Batal
                 </UButton>
-                <UButton
-                  v-if="user?.avatar"
-                  icon="i-lucide-trash-2"
-                  size="sm"
-                  color="error"
-                  variant="ghost"
-                  :loading="avatarDeleting"
-                  @click="deleteAvatar"
-                >
-                  Hapus
+                <UButton type="submit" color="primary" :loading="profileSaving">
+                  Simpan Perubahan
                 </UButton>
               </div>
-              <p class="text-xs text-neutral-500">
-                JPG, PNG, atau WebP. Maksimal 2MB.
-              </p>
-            </div>
-            <input
-              ref="fileInput"
-              type="file"
-              accept="image/jpeg,image/png,image/webp"
-              class="hidden"
-              @change="onFileChange"
-            >
+            </form>
           </div>
-        </UCard>
+        </template>
 
-        <!-- Section 2: Data Diri -->
-        <UCard>
-          <template #header>
-            <h3 class="text-sm font-semibold text-neutral-700">
-              Data Diri
-            </h3>
-          </template>
+        <template #keamanan>
+          <div class="mt-4 rounded-xl border border-neutral-200 bg-white p-6">
+            <form class="space-y-5" @submit.prevent="savePassword">
+              <UFormField label="Password Lama" name="oldPassword" required>
+                <UInput
+                  v-model="passwordForm.oldPassword"
+                  type="password"
+                  :disabled="passwordSaving"
+                  class="w-full"
+                />
+              </UFormField>
 
-          <form class="space-y-4" @submit.prevent="saveProfile">
-            <UFormField label="Nama lengkap" required>
-              <UInput v-model="profileForm.name" :disabled="profileSaving" class="w-full" />
-            </UFormField>
-            <UFormField label="Username" required>
-              <UInput v-model="profileForm.username" :disabled="profileSaving" class="w-full" />
-            </UFormField>
-            <UFormField label="Email" required>
-              <UInput v-model="profileForm.email" type="email" :disabled="profileSaving" class="w-full" />
-            </UFormField>
+              <UFormField label="Password Baru" name="newPassword" required hint="Minimal 8 karakter">
+                <UInput
+                  v-model="passwordForm.newPassword"
+                  type="password"
+                  :disabled="passwordSaving"
+                  class="w-full"
+                />
+              </UFormField>
 
-            <p v-if="profileError" class="text-sm text-red-600 bg-red-50 rounded px-3 py-2">
-              {{ profileError }}
-            </p>
+              <UFormField label="Konfirmasi Password Baru" name="confirmPassword" required>
+                <UInput
+                  v-model="passwordForm.confirmPassword"
+                  type="password"
+                  :disabled="passwordSaving"
+                  class="w-full"
+                />
+              </UFormField>
 
-            <div class="flex justify-end">
-              <UButton
-                type="submit"
-                color="primary"
-                :loading="profileSaving"
-              >
-                Simpan Perubahan
-              </UButton>
-            </div>
-          </form>
-        </UCard>
+              <p v-if="passwordError" class="rounded bg-red-50 px-3 py-2 text-sm text-red-600">
+                {{ passwordError }}
+              </p>
 
-        <!-- Section 3: Password -->
-        <UCard>
-          <template #header>
-            <h3 class="text-sm font-semibold text-neutral-700">
-              Ganti Password
-            </h3>
-          </template>
-
-          <form class="space-y-4" @submit.prevent="savePassword">
-            <UFormField label="Password lama" required>
-              <UInput
-                v-model="passwordForm.oldPassword"
-                type="password"
-                :disabled="passwordSaving"
-                class="w-full"
-              />
-            </UFormField>
-            <UFormField label="Password baru" required help="Minimal 8 karakter">
-              <UInput
-                v-model="passwordForm.newPassword"
-                type="password"
-                :disabled="passwordSaving"
-                class="w-full"
-              />
-            </UFormField>
-            <UFormField label="Konfirmasi password baru" required>
-              <UInput
-                v-model="passwordForm.confirmPassword"
-                type="password"
-                :disabled="passwordSaving"
-                class="w-full"
-              />
-            </UFormField>
-
-            <p v-if="passwordError" class="text-sm text-red-600 bg-red-50 rounded px-3 py-2">
-              {{ passwordError }}
-            </p>
-
-            <div class="flex justify-end">
-              <UButton
-                type="submit"
-                color="primary"
-                :loading="passwordSaving"
-              >
-                Ganti Password
-              </UButton>
-            </div>
-          </form>
-        </UCard>
+              <div class="flex justify-end">
+                <UButton type="submit" color="primary" :loading="passwordSaving">
+                  Ganti Password
+                </UButton>
+              </div>
+            </form>
+          </div>
+        </template>
+      </UTabs>
     </div>
-  </AppContent>
+  </UContainer>
 </template>

--- a/app/pages/pena-santri/[slug].vue
+++ b/app/pages/pena-santri/[slug].vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+const route = useRoute()
+const slug = route.params.slug as string
+
+const { data, error } = await useFetch(`/api/public/posts/${slug}`, {
+  key: `public-post-${slug}`,
+})
+
+if (error.value?.statusCode === 404 || !data.value?.post) {
+  throw createError({ statusCode: 404, statusMessage: 'Halaman tidak ditemukan' })
+}
+
+const post = computed(() => data.value!.post)
+
+useSeoMeta({
+  title: post.value.title,
+  description: post.value.excerpt ?? undefined,
+  ogTitle: post.value.title,
+  ogDescription: post.value.excerpt ?? undefined,
+  ogImage: post.value.featuredImage ?? undefined,
+  ogType: 'article',
+})
+
+useHead({
+  script: [{
+    type: 'application/ld+json',
+    children: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: post.value.title,
+      datePublished: post.value.publishedAt ?? post.value.createdAt,
+      author: { '@type': 'Person', name: post.value.authorName },
+      image: post.value.featuredImage,
+    }),
+  }],
+})
+</script>
+
+<template>
+  <PublicPostDetail
+    :post="post"
+    back-path="/pena-santri"
+    back-label="Pena Santri"
+  />
+</template>

--- a/server/api/dashboard/profile/index.patch.ts
+++ b/server/api/dashboard/profile/index.patch.ts
@@ -8,9 +8,19 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 export default defineEventHandler(async (event) => {
   const currentUser = requireAuth(event)
 
-  const body = await readBody<{ name?: string, username?: string, email?: string }>(event)
+  const body = await readBody<{
+    name?: string
+    username?: string
+    email?: string
+    phone?: string | null
+    university?: string | null
+    faculty?: string | null
+    major?: string | null
+    yearEnrolled?: number | null
+  }>(event)
 
   const updates: Partial<typeof schema.users.$inferInsert> = {}
+
   if (body.name !== undefined) {
     const name = body.name.trim()
     if (!name) throw createError({ statusCode: 400, message: 'Nama tidak boleh kosong.' })
@@ -25,6 +35,17 @@ export default defineEventHandler(async (event) => {
     const email = body.email.trim().toLowerCase()
     if (!EMAIL_REGEX.test(email)) throw createError({ statusCode: 400, message: 'Format email tidak valid.' })
     updates.email = email
+  }
+  if ('phone' in body) updates.phone = body.phone ?? null
+  if ('university' in body) updates.university = body.university ?? null
+  if ('faculty' in body) updates.faculty = body.faculty ?? null
+  if ('major' in body) updates.major = body.major ?? null
+  if ('yearEnrolled' in body) {
+    const yr = body.yearEnrolled
+    if (yr !== null && yr !== undefined && (yr < 1901 || yr > 2155)) {
+      throw createError({ statusCode: 400, message: 'Tahun angkatan tidak valid.' })
+    }
+    updates.yearEnrolled = yr ?? null
   }
 
   if (Object.keys(updates).length === 0) {

--- a/server/api/public/posts/[slug].get.ts
+++ b/server/api/public/posts/[slug].get.ts
@@ -1,0 +1,48 @@
+import { drizzle } from 'drizzle-orm/mysql2'
+import mysql from 'mysql2/promise'
+import { and, eq } from 'drizzle-orm'
+import * as schema from '~~/server/db/schema'
+
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+  if (!slug) throw createError({ statusCode: 400, message: 'Slug diperlukan.' })
+
+  const mysqlUrl = process.env.MYSQL_URL
+  if (!mysqlUrl) throw createError({ statusCode: 500, message: 'Database tidak terkonfigurasi.' })
+
+  const connection = await mysql.createConnection(mysqlUrl)
+  const db = drizzle(connection, { schema, casing: 'snake_case', mode: 'default' })
+
+  try {
+    const rows = await db.select({
+      id: schema.posts.id,
+      title: schema.posts.title,
+      slug: schema.posts.slug,
+      content: schema.posts.content,
+      excerpt: schema.posts.excerpt,
+      featuredImage: schema.posts.featuredImage,
+      publishedAt: schema.posts.publishedAt,
+      createdAt: schema.posts.createdAt,
+      categorySlug: schema.categories.slug,
+      categoryName: schema.categories.name,
+      categoryType: schema.categories.type,
+      authorName: schema.users.name,
+    })
+      .from(schema.posts)
+      .innerJoin(schema.categories, eq(schema.posts.categoryId, schema.categories.id))
+      .innerJoin(schema.users, eq(schema.posts.authorId, schema.users.id))
+      .where(and(
+        eq(schema.posts.slug, slug),
+        eq(schema.posts.status, 'published'),
+      ))
+      .limit(1)
+
+    const post = rows[0]
+    if (!post) throw createError({ statusCode: 404, message: 'Post tidak ditemukan.' })
+
+    return { post }
+  }
+  finally {
+    await connection.end()
+  }
+})


### PR DESCRIPTION
## Overview
Implements two features on the same branch: santri profile page (OJI-41) and reusable post detail pages for berita and pena santri (OJI-29).

## Changes

### OJI-41 — Profil Saya (Santri)
- `app/pages/dashboard/profile/index.vue` — Rebuilt profile page with avatar card header, UTabs for "Informasi Pribadi" and "Keamanan" tabs; academic fields (phone, university, faculty, major, yearEnrolled)
- `server/api/dashboard/profile/index.patch.ts` — Extended PATCH endpoint with new academic fields; MySQL YEAR bounds check (1901–2155)

### OJI-29 — Post Detail Pages
- `server/api/public/posts/[slug].get.ts` — Public API: fetch single published post by slug with category + author join
- `app/components/public/PostDetail.vue` — Reusable post detail component: back nav, title, meta, featured image (aspect-video), prose content, social share links (Facebook, Twitter, WhatsApp, LinkedIn), Disqus comments
- `app/pages/berita/[slug].vue` — Berita detail page with SEO meta + Article JSON-LD
- `app/pages/pena-santri/[slug].vue` — Pena Santri detail page, same pattern

## Testing
- Visit `/berita/[slug]` and `/pena-santri/[slug]` with a published post slug
- Verify title, author, date, featured image, content, and share links render correctly
- Verify Disqus loads client-side
- Verify 404 for non-existent or unpublished post slug
- Visit `/dashboard/profile` as a santri user — check both tabs, edit academic fields, save
- Test password change flow in "Keamanan" tab

## Linear
- OJI-41: https://linear.app/omah-ngaji/issue/OJI-41
- OJI-29: https://linear.app/omah-ngaji/issue/OJI-29